### PR TITLE
Fix "No such file or directory (os error 2)"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,16 +140,19 @@ fn main() {
         handle.await_complete();
     }
 
-    set_folder_writable(&path);
+    if path.exists() {
+        // Try to fix permisssion issues and delete again
+        set_folder_writable(&path);
 
-    std::fs::remove_dir_all(path).unwrap_or_else(|err| {
-        eprintln!(
-            "{} {}",
-            " ERROR ".on_color(AnsiColors::BrightRed).black(),
-            err
-        );
-        std::process::exit(1);
-    });
+        std::fs::remove_dir_all(path).unwrap_or_else(|err| {
+            eprintln!(
+                "{} {}",
+                " ERROR ".on_color(AnsiColors::BrightRed).black(),
+                err
+            );
+            std::process::exit(1);
+        });
+    }
 
     bar.println(format!("{}", start.elapsed().as_secs_f32()));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,42 @@ pub fn set_writable(path: &Path) {
     std::fs::set_permissions(path, perms).unwrap();
 }
 
+pub fn set_folder_writable(path: &Path) {
+    // get complete list of folders
+    let entries: Vec<DirEntry<((), ())>> = jwalk::WalkDir::new(&path)
+        .follow_links(true)
+        .skip_hidden(false)
+        .into_iter()
+        .filter(|v| {
+            v.as_ref()
+                .unwrap_or_else(|err| {
+                    eprintln!(
+                        "{} {}",
+                        " ERROR ".on_color(AnsiColors::BrightRed).black(),
+                        err
+                    );
+                    std::process::exit(1);
+                })
+                .path()
+                .is_file()
+        })
+        .map(|v| {
+            v.unwrap_or_else(|err| {
+                eprintln!(
+                    "{} {}",
+                    " ERROR ".on_color(AnsiColors::BrightRed).black(),
+                    err
+                );
+                std::process::exit(1);
+            })
+        })
+        .collect::<Vec<DirEntry<((), ())>>>();
+
+    entries.par_iter().for_each(|entry| {
+        set_writable(&entry.path());
+    });
+}
+
 fn main() {
     let start = Instant::now();
 
@@ -104,39 +140,7 @@ fn main() {
         handle.await_complete();
     }
 
-    // get complete list of folders
-    let entries: Vec<DirEntry<((), ())>> = jwalk::WalkDir::new(&path)
-        .follow_links(true)
-        .skip_hidden(false)
-        .into_iter()
-        .filter(|v| {
-            v.as_ref()
-                .unwrap_or_else(|err| {
-                    eprintln!(
-                        "{} {}",
-                        " ERROR ".on_color(AnsiColors::BrightRed).black(),
-                        err
-                    );
-                    std::process::exit(1);
-                })
-                .path()
-                .is_file()
-        })
-        .map(|v| {
-            v.unwrap_or_else(|err| {
-                eprintln!(
-                    "{} {}",
-                    " ERROR ".on_color(AnsiColors::BrightRed).black(),
-                    err
-                );
-                std::process::exit(1);
-            })
-        })
-        .collect::<Vec<DirEntry<((), ())>>>();
-
-    entries.par_iter().for_each(|entry| {
-        set_writable(&entry.path());
-    });
+    set_folder_writable(&path);
 
     std::fs::remove_dir_all(path).unwrap_or_else(|err| {
         eprintln!(


### PR DESCRIPTION
Fixes https://github.com/XtremeDevX/turbo-delete/issues/2





It seems that after the function call `handle.await_complete();`, **the threads were exetuted and the folders has been already deleted.**

However, the following lines https://github.com/XtremeDevX/turbo-delete/blob/0.0.1/src/main.rs#L108-L135 still tried to access the deleted folders and it reports IO error.

**So I check whether the path exists before iterating the path again.**

BTW, I have done some small code refactoring, extracted a new function : )

---

**Before Fix:**
![Screenshot 2022-04-09 165337](https://user-images.githubusercontent.com/51704722/162566685-70f7fddc-946e-443d-97d8-a807ae28800a.png)

**After fix:**
![Screenshot 2022-04-09 173532](https://user-images.githubusercontent.com/51704722/162566673-51e28a1b-1ced-4303-a81c-6ffa61ae9fbf.png)

